### PR TITLE
include file extensions in all ESM imports

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { WakuRelayerClient } from '../index';
+import { WakuRelayerClient } from '../index.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/src/__tests__/waku-relayer-client.test.ts
+++ b/src/__tests__/waku-relayer-client.test.ts
@@ -1,4 +1,4 @@
-/// <reference types="../types/index" />
+/// <reference types="../types/index.js" />
 import {
   Chain,
   poll,
@@ -7,10 +7,10 @@ import {
 } from '@railgun-community/shared-models';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { WakuRelayerClient } from '../waku-relayer-client';
-import { MOCK_CHAIN_ETHEREUM, MOCK_CHAIN_GOERLI } from '../tests/mocks.test';
-import { WakuRelayerWakuCore } from '../waku/waku-relayer-waku-core';
-import { RelayerOptions } from '../models';
+import { WakuRelayerClient } from '../waku-relayer-client.js';
+import { MOCK_CHAIN_ETHEREUM, MOCK_CHAIN_GOERLI } from '../tests/mocks.test.js';
+import { WakuRelayerWakuCore } from '../waku/waku-relayer-waku-core.js';
+import { RelayerOptions } from '../models/index.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/src/fees/__tests__/handle-fees-message.test.ts
+++ b/src/fees/__tests__/handle-fees-message.test.ts
@@ -18,12 +18,12 @@ import {
   MOCK_DB_ENCRYPTION_KEY,
   MOCK_MNEMONIC,
   MOCK_MNEMONIC_2,
-} from '../../tests/mocks.test';
-import { initTestEngine } from '../../tests/setup.test';
-import { utf8ToBytes } from '../../utils/conversion';
-import { contentTopics } from '../../waku/waku-topics';
-import { handleRelayerFeesMessage } from '../handle-fees-message';
-import { RelayerFeeCache } from '../relayer-fee-cache';
+} from '../../tests/mocks.test.js';
+import { initTestEngine } from '../../tests/setup.test.js';
+import { utf8ToBytes } from '../../utils/conversion.js';
+import { contentTopics } from '../../waku/waku-topics.js';
+import { handleRelayerFeesMessage } from '../handle-fees-message.js';
+import { RelayerFeeCache } from '../relayer-fee-cache.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/src/fees/__tests__/relayer-fee-cache.test.ts
+++ b/src/fees/__tests__/relayer-fee-cache.test.ts
@@ -1,9 +1,9 @@
-/// <reference types="../../types/index" />
+/// <reference types="../../types/index.js" />
 import { CachedTokenFee } from '@railgun-community/shared-models';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { MOCK_CHAIN_ETHEREUM } from '../../tests/mocks.test';
-import { RelayerFeeCache, RelayerFeeCacheState } from '../relayer-fee-cache';
+import { MOCK_CHAIN_ETHEREUM } from '../../tests/mocks.test.js';
+import { RelayerFeeCache, RelayerFeeCacheState } from '../relayer-fee-cache.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/src/fees/handle-fees-message.ts
+++ b/src/fees/handle-fees-message.ts
@@ -9,13 +9,13 @@ import {
 } from '@railgun-community/shared-models';
 import crypto from 'crypto';
 import { IMessage } from '@waku/interfaces';
-import { contentTopics } from '../waku/waku-topics';
-import { RelayerDebug } from '../utils/relayer-debug';
-import { RelayerConfig } from '../models/relayer-config';
-import { RelayerFeeCache } from './relayer-fee-cache';
-import { invalidRelayerVersion } from '../utils/relayer-util';
-import { bytesToUtf8, hexToUTF8String } from '../utils/conversion';
-import { isDefined } from '../utils/is-defined';
+import { contentTopics } from '../waku/waku-topics.js';
+import { RelayerDebug } from '../utils/relayer-debug.js';
+import { RelayerConfig } from '../models/relayer-config.js';
+import { RelayerFeeCache } from './relayer-fee-cache.js';
+import { invalidRelayerVersion } from '../utils/relayer-util.js';
+import { bytesToUtf8, hexToUTF8String } from '../utils/conversion.js';
+import { isDefined } from '../utils/is-defined.js';
 
 const isExpiredTimestamp = (timestamp: Optional<Date>) => {
   if (!timestamp) {

--- a/src/fees/relayer-fee-cache.ts
+++ b/src/fees/relayer-fee-cache.ts
@@ -3,16 +3,16 @@ import {
   Chain,
   networkForChain,
 } from '@railgun-community/shared-models';
-import { AddressFilter } from '../filters/address-filter';
-import { RelayerConfig } from '../models/relayer-config';
-import { RelayerDebug } from '../utils/relayer-debug';
+import { AddressFilter } from '../filters/address-filter.js';
+import { RelayerConfig } from '../models/relayer-config.js';
+import { RelayerDebug } from '../utils/relayer-debug.js';
 import {
   nameForRelayer,
   cachedFeeExpired,
   DEFAULT_RELAYER_IDENTIFIER,
   invalidRelayerVersion,
   cachedFeeUnavailableOrExpired,
-} from '../utils/relayer-util';
+} from '../utils/relayer-util.js';
 
 // {forNetwork: {forToken: {forRelayer: (fee, updatedAt)}}}
 type RelayerFeeNetworkTokenRelayerCacheMap = {

--- a/src/filters/__tests__/address-filter.test.ts
+++ b/src/filters/__tests__/address-filter.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { AddressFilter } from '../address-filter';
+import { AddressFilter } from '../address-filter.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from './waku-relayer-client';
-export * from './models';
-export * from './transact';
+export * from './waku-relayer-client.js';
+export * from './models/index.js';
+export * from './transact/index.js';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,1 +1,1 @@
-export * from './export-models';
+export * from './export-models.js';

--- a/src/search/best-relayer.ts
+++ b/src/search/best-relayer.ts
@@ -1,12 +1,12 @@
 import { Chain, SelectedRelayer } from '@railgun-community/shared-models';
-import { RelayerFeeCache } from '../fees/relayer-fee-cache';
-import { AddressFilter } from '../filters/address-filter';
-import { RelayerDebug } from '../utils/relayer-debug';
+import { RelayerFeeCache } from '../fees/relayer-fee-cache.js';
+import { AddressFilter } from '../filters/address-filter.js';
+import { RelayerDebug } from '../utils/relayer-debug.js';
 import {
   cachedFeeUnavailableOrExpired,
   shortenAddress,
-} from '../utils/relayer-util';
-import { isDefined } from '../utils/is-defined';
+} from '../utils/relayer-util.js';
+import { isDefined } from '../utils/is-defined.js';
 
 export class RelayerSearch {
   static findBestRelayer(

--- a/src/status/relayer-connection-status.ts
+++ b/src/status/relayer-connection-status.ts
@@ -3,11 +3,11 @@ import {
   Chain,
   RelayerConnectionStatus,
 } from '@railgun-community/shared-models';
-import { RelayerFeeCache } from '../fees/relayer-fee-cache';
-import { AddressFilter } from '../filters/address-filter';
-import { cachedFeeExpired } from '../utils/relayer-util';
-import { WakuRelayerWakuCore } from '../waku/waku-relayer-waku-core';
-import { isDefined } from '../utils/is-defined';
+import { RelayerFeeCache } from '../fees/relayer-fee-cache.js';
+import { AddressFilter } from '../filters/address-filter.js';
+import { cachedFeeExpired } from '../utils/relayer-util.js';
+import { WakuRelayerWakuCore } from '../waku/waku-relayer-waku-core.js';
+import { isDefined } from '../utils/is-defined.js';
 
 export class RelayerStatus {
   static getRelayerConnectionStatus(chain: Chain): RelayerConnectionStatus {

--- a/src/tests/setup.test.ts
+++ b/src/tests/setup.test.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { ArtifactStore, startRailgunEngine } from '@railgun-community/wallet';
 
 const TEST_DB = 'test.db';
+// @ts-ignore
 const db = new LevelDOWN(TEST_DB);
 
 before(() => {});

--- a/src/transact/__tests__/relayer-transaction.test.ts
+++ b/src/transact/__tests__/relayer-transaction.test.ts
@@ -4,19 +4,19 @@ import {
   MOCK_CHAIN_ETHEREUM,
   MOCK_FALLBACK_PROVIDER_JSON_CONFIG,
   MOCK_RAILGUN_WALLET_ADDRESS,
-} from '../../tests/mocks.test';
+} from '../../tests/mocks.test.js';
 import sinon, { SinonStub } from 'sinon';
-import { WakuRelayerWakuCore } from '../../waku/waku-relayer-waku-core';
-import { RelayerTransaction } from '../relayer-transaction';
+import { WakuRelayerWakuCore } from '../../waku/waku-relayer-waku-core.js';
+import { RelayerTransaction } from '../relayer-transaction.js';
 import {
   TXIDVersion,
   delay,
   networkForChain,
 } from '@railgun-community/shared-models';
-import { RelayerTransactResponse } from '../relayer-transact-response';
-import { utf8ToBytes } from '../../utils/conversion';
+import { RelayerTransactResponse } from '../relayer-transact-response.js';
+import { utf8ToBytes } from '../../utils/conversion.js';
 import { encryptJSONDataWithSharedKey } from '@railgun-community/engine';
-import { initTestEngine } from '../../tests/setup.test';
+import { initTestEngine } from '../../tests/setup.test.js';
 import { loadProvider } from '@railgun-community/wallet';
 
 chai.use(chaiAsPromised);

--- a/src/transact/index.ts
+++ b/src/transact/index.ts
@@ -1,1 +1,1 @@
-export * from './relayer-transaction';
+export * from './relayer-transaction.js';

--- a/src/transact/relayer-transact-response.ts
+++ b/src/transact/relayer-transact-response.ts
@@ -1,8 +1,8 @@
 import { decryptAESGCM256 } from '@railgun-community/wallet';
 import { IMessage } from '@waku/interfaces';
-import { bytesToUtf8 } from '../utils/conversion';
-import { RelayerDebug } from '../utils/relayer-debug';
-import { isDefined } from '../utils/is-defined';
+import { bytesToUtf8 } from '../utils/conversion.js';
+import { RelayerDebug } from '../utils/relayer-debug.js';
+import { isDefined } from '../utils/is-defined.js';
 
 export type WakuTransactResponse = {
   id: string;

--- a/src/transact/relayer-transaction.ts
+++ b/src/transact/relayer-transaction.ts
@@ -12,16 +12,16 @@ import {
   RelayerRawParamsTransact,
   TXIDVersion,
 } from '@railgun-community/shared-models';
-import { RelayerConfig } from '../models/relayer-config';
-import { bytesToHex } from '../utils/conversion';
-import { RelayerDebug } from '../utils/relayer-debug';
-import { isDefined } from '../utils/is-defined';
-import { WakuRelayerWakuCore } from '../waku/waku-relayer-waku-core';
-import { contentTopics } from '../waku/waku-topics';
+import { RelayerConfig } from '../models/relayer-config.js';
+import { bytesToHex } from '../utils/conversion.js';
+import { RelayerDebug } from '../utils/relayer-debug.js';
+import { isDefined } from '../utils/is-defined.js';
+import { WakuRelayerWakuCore } from '../waku/waku-relayer-waku-core.js';
+import { contentTopics } from '../waku/waku-topics.js';
 import {
   WakuTransactResponse,
   RelayerTransactResponse,
-} from './relayer-transact-response';
+} from './relayer-transact-response.js';
 import { getAddress, isHexString } from 'ethers';
 
 //

--- a/src/utils/__tests__/is-defined.test.ts
+++ b/src/utils/__tests__/is-defined.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { isDefined } from '../is-defined';
+import { isDefined } from '../is-defined.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/src/utils/__tests__/relayer-util.test.ts
+++ b/src/utils/__tests__/relayer-util.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { cachedFeeExpired, nameForRelayer } from '../relayer-util';
+import { cachedFeeExpired, nameForRelayer } from '../relayer-util.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/src/utils/relayer-debug.ts
+++ b/src/utils/relayer-debug.ts
@@ -1,4 +1,4 @@
-import { RelayerDebugger } from '../models/export-models';
+import { RelayerDebugger } from '../models/export-models.js';
 
 export class RelayerDebug {
   private static debug: Optional<RelayerDebugger>;

--- a/src/utils/relayer-util.ts
+++ b/src/utils/relayer-util.ts
@@ -4,8 +4,8 @@ import {
   networkForChain,
   versionCompare,
 } from '@railgun-community/shared-models';
-import { RelayerConfig } from '../models/relayer-config';
-import { isDefined } from './is-defined';
+import { RelayerConfig } from '../models/relayer-config.js';
+import { isDefined } from './is-defined.js';
 
 const FEE_EXPIRATION_MINIMUM_MSEC = 40000;
 

--- a/src/waku-relayer-client.ts
+++ b/src/waku-relayer-client.ts
@@ -5,18 +5,18 @@ import {
   RelayerConnectionStatus,
   SelectedRelayer,
 } from '@railgun-community/shared-models';
-import { RelayerFeeCache } from './fees/relayer-fee-cache';
-import { AddressFilter } from './filters/address-filter';
+import { RelayerFeeCache } from './fees/relayer-fee-cache.js';
+import { AddressFilter } from './filters/address-filter.js';
 import {
   RelayerConnectionStatusCallback,
   RelayerDebugger,
   RelayerOptions,
-} from './models/export-models';
-import { RelayerSearch } from './search/best-relayer';
-import { RelayerStatus } from './status/relayer-connection-status';
-import { RelayerDebug } from './utils/relayer-debug';
-import { WakuObservers } from './waku/waku-observers';
-import { WakuRelayerWakuCore } from './waku/waku-relayer-waku-core';
+} from './models/export-models.js';
+import { RelayerSearch } from './search/best-relayer.js';
+import { RelayerStatus } from './status/relayer-connection-status.js';
+import { RelayerDebug } from './utils/relayer-debug.js';
+import { WakuObservers } from './waku/waku-observers.js';
+import { WakuRelayerWakuCore } from './waku/waku-relayer-waku-core.js';
 
 export class WakuRelayerClient {
   private static chain: Chain;

--- a/src/waku/__tests__/waku-topics.test.ts
+++ b/src/waku/__tests__/waku-topics.test.ts
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { contentTopics } from '../waku-topics';
-import { MOCK_CHAIN_ETHEREUM } from '../../tests/mocks.test';
+import { contentTopics } from '../waku-topics.js';
+import { MOCK_CHAIN_ETHEREUM } from '../../tests/mocks.test.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/src/waku/waku-observers.ts
+++ b/src/waku/waku-observers.ts
@@ -1,12 +1,12 @@
 import { Chain, compareChains } from '@railgun-community/shared-models';
 import { createDecoder } from '@waku/core';
-import { contentTopics } from './waku-topics';
+import { contentTopics } from './waku-topics.js';
 import { RelayNode, IMessage } from '@waku/interfaces';
-import { handleRelayerFeesMessage } from '../fees/handle-fees-message';
-import { RelayerTransactResponse } from '../transact/relayer-transact-response';
-import { RelayerDebug } from '../utils/relayer-debug';
+import { handleRelayerFeesMessage } from '../fees/handle-fees-message.js';
+import { RelayerTransactResponse } from '../transact/relayer-transact-response.js';
+import { RelayerDebug } from '../utils/relayer-debug.js';
 import { ContentTopic } from '@waku/relay';
-import { isDefined } from '../utils/is-defined';
+import { isDefined } from '../utils/is-defined.js';
 
 export class WakuObservers {
   private static currentChain: Optional<Chain>;

--- a/src/waku/waku-relayer-waku-core.ts
+++ b/src/waku/waku-relayer-waku-core.ts
@@ -1,19 +1,19 @@
 import { Chain, promiseTimeout } from '@railgun-community/shared-models';
 import { waitForRemotePeer, createEncoder } from '@waku/core';
 import { Protocols, IMessage, RelayNode } from '@waku/interfaces';
-import { WakuObservers } from './waku-observers';
-import { RelayerDebug } from '../utils/relayer-debug';
-import { RelayerFeeCache } from '../fees/relayer-fee-cache';
-import { utf8ToBytes } from '../utils/conversion';
-import { isDefined } from '../utils/is-defined';
+import { WakuObservers } from './waku-observers.js';
+import { RelayerDebug } from '../utils/relayer-debug.js';
+import { RelayerFeeCache } from '../fees/relayer-fee-cache.js';
+import { utf8ToBytes } from '../utils/conversion.js';
+import { isDefined } from '../utils/is-defined.js';
 import { bootstrap } from '@libp2p/bootstrap';
 import { tcp } from '@libp2p/tcp';
 import { createRelayNode } from '@waku/create';
-import { RelayerOptions } from '../models';
+import { RelayerOptions } from '../models/index.js';
 import {
   WAKU_RAILGUN_DEFAULT_PEERS,
   WAKU_RAILGUN_PUB_SUB_TOPIC,
-} from '../models/constants';
+} from '../models/constants.js';
 
 export class WakuRelayerWakuCore {
   static hasError = false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "node": true
   },
   "compilerOptions": {
-    "target": "es6",
-    "module": "esnext",
+    "target": "es2021",
+    "module": "nodenext",
     "sourceMap": true,
     "inlineSources": true,
     "declaration": true,
@@ -25,7 +25,7 @@
     "removeComments": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "isolatedModules": true,
     "noImplicitReturns": true,
     "useUnknownInCatchVariables": false,


### PR DESCRIPTION
## Context

Fixes issue #7, i.e. when using waku-relayer-client in Node.js **without** any bundler (or with a bundler set up with specific configurations).

## Problem

Waku is exported only in ESM, not CommonJS, so this forces waku-relayer-client to be ESM-only too. When that's the case, we are actually using ESM incorrectly, because we have to `import { foo } from './foo.js` not `import { foo } from './foo'`.

## Solution

This PR adds file extensions to all ESM imports, and tweaks the tsconfig.json accordingly.

## Tests

- Unit tests pass locally
- Used this in a Nest demo like issue #7 showed, and it worked
- Used this in a RAILGUN Web app, and it worked
- Used this in a RAILGUN Mobile app, and it worked