### PR TITLE
Support developing on macOS

### DIFF
--- a/packages/common/copy-src
+++ b/packages/common/copy-src
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-PACKAGES="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
-
-for PACKAGE in node web; do
-  mkdir -p $PACKAGES/$PACKAGE/src
-  cp --recursive --symbolic-link --no-clobber $PACKAGES/common/src/* $PACKAGES/$PACKAGE/src/
-done

--- a/packages/common/copy-src.js
+++ b/packages/common/copy-src.js
@@ -1,0 +1,31 @@
+const FS = require('fs');
+const Path = require('path');
+
+function copyDirectoryWithLinks(src, dst) {
+  if (!FS.existsSync(dst)) {
+    FS.mkdirSync(dst);
+  }
+  for (const file of FS.readdirSync(src)) {
+    const srcPath = Path.join(src, file);
+    const dstPath = Path.join(dst, file);
+
+    if (FS.lstatSync(srcPath).isDirectory()) {
+      if (!FS.existsSync(dstPath)) {
+        FS.mkdirSync(dstPath);
+      }
+      copyDirectoryWithLinks(srcPath, dstPath);
+    } else if (FS.existsSync(dstPath)) {
+      continue;
+    } else {
+      FS.symlinkSync(srcPath, dstPath);
+    }
+  }
+}
+
+const packages = Path.resolve(__dirname, '..');
+for (const package of ['node', 'web']) {
+  copyDirectoryWithLinks(
+    Path.join(packages, 'common', 'src'),
+    Path.join(packages, package, 'src'),
+  );
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.5",
   "license": "MIT",
   "scripts": {
-    "postinstall": "./copy-src",
+    "postinstall": "node copy-src.js",
     "clean": "rm -rf dist",
     "build": "npm run clean && tsc",
     "check-circular-deps": "madge --circular .",


### PR DESCRIPTION
Turns out the `copy-src` bash script is using `cp` in a way that is GNU-specific and not supported by macOS. In this PR I replace that with a `copy-src.js` Node.js script which is cross platform.