### PR TITLE
Remove irrelevant deps

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,9 +15,6 @@
     "test": "npm run compile-test && NODE_ENV=test mocha"
   },
   "dependencies": {
-    "@libp2p/bootstrap": "^10.0.11",
-    "@libp2p/interface-peer-id": "^2.0.2",
-    "@libp2p/tcp": "9.0.17",
     "@waku/core": "0.0.27",
     "@waku/interfaces": "0.0.22",
     "@waku/relay": "0.0.10",

--- a/packages/common/yarn.lock
+++ b/packages/common/yarn.lock
@@ -1015,13 +1015,6 @@
     "@multiformats/multiaddr" "^12.1.14"
     uint8arraylist "^2.4.8"
 
-"@libp2p/interface-peer-id@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz#6302e70b6fc17c451bc3daa11447d059357bcc32"
-  integrity sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==
-  dependencies:
-    multiformats "^11.0.0"
-
 "@libp2p/interface@^1.0.0", "@libp2p/interface@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-1.1.4.tgz#21c7bbbe7628419d1e4902f0c953db1423b0f40f"
@@ -1195,18 +1188,6 @@
     p-queue "^8.0.1"
     uint8arraylist "^2.4.8"
     uint8arrays "^5.0.2"
-
-"@libp2p/tcp@9.0.17":
-  version "9.0.17"
-  resolved "https://registry.yarnpkg.com/@libp2p/tcp/-/tcp-9.0.17.tgz#f0f44d189b098f49e07f8426abda86ad50d753ac"
-  integrity sha512-joGy4Zs/2jQ1pe8fD7yr9lLqJ2ZXxZN6dZhhzknf3Opq1YRQ3yyz2eu5G1LNdN0jqyO259UO+TnLtEkruel/QQ==
-  dependencies:
-    "@libp2p/interface" "^1.1.5"
-    "@libp2p/utils" "^5.2.7"
-    "@multiformats/mafmt" "^12.1.6"
-    "@multiformats/multiaddr" "^12.1.14"
-    "@types/sinon" "^17.0.3"
-    stream-to-it "^0.2.4"
 
 "@libp2p/utils@^5.2.7":
   version "5.2.7"
@@ -1809,13 +1790,6 @@
   version "10.0.15"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.15.tgz#513fded9c3cf85e589bbfefbf02b2a0541186b48"
   integrity sha512-3lrFNQG0Kr2LDzvjyjB6AMJk4ge+8iYhQfdnSwIwlG88FUOV43kPcQqDZkDa/h3WSZy6i8Fr0BSjfQtB1B3xuQ==
-  dependencies:
-    "@types/sinonjs__fake-timers" "*"
-
-"@types/sinon@^17.0.3":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-17.0.3.tgz#9aa7e62f0a323b9ead177ed23a36ea757141a5fa"
-  integrity sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==
   dependencies:
     "@types/sinonjs__fake-timers" "*"
 
@@ -4353,11 +4327,6 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.3"
-
-get-iterator@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-iterator/-/get-iterator-1.0.2.tgz#cd747c02b4c084461fac14f48f6b45a80ed25c82"
-  integrity sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==
 
 get-iterator@^2.0.1:
   version "2.0.1"
@@ -7051,13 +7020,6 @@ stream-to-array@^2.3.0:
   integrity sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==
   dependencies:
     any-promise "^1.1.0"
-
-stream-to-it@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/stream-to-it/-/stream-to-it-0.2.4.tgz#d2fd7bfbd4a899b4c0d6a7e6a533723af5749bd0"
-  integrity sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==
-  dependencies:
-    get-iterator "^1.0.2"
 
 streamsearch@^1.1.0:
   version "1.1.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@libp2p/bootstrap": "^10.0.11",
-    "@libp2p/interface-peer-id": "^2.0.2",
     "@libp2p/tcp": "9.0.17",
     "@waku/core": "0.0.27",
     "@waku/relay": "0.0.10",

--- a/packages/node/yarn.lock
+++ b/packages/node/yarn.lock
@@ -1015,13 +1015,6 @@
     "@multiformats/multiaddr" "^12.1.14"
     uint8arraylist "^2.4.8"
 
-"@libp2p/interface-peer-id@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz#6302e70b6fc17c451bc3daa11447d059357bcc32"
-  integrity sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==
-  dependencies:
-    multiformats "^11.0.0"
-
 "@libp2p/interface@^1.0.0", "@libp2p/interface@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-1.1.4.tgz#21c7bbbe7628419d1e4902f0c953db1423b0f40f"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@libp2p/bootstrap": "^10.0.11",
-    "@libp2p/interface-peer-id": "^2.0.2",
     "@waku/core": "0.0.27",
     "@waku/relay": "0.0.10",
     "@waku/sdk": "0.0.23",

--- a/packages/web/yarn.lock
+++ b/packages/web/yarn.lock
@@ -1011,13 +1011,6 @@
     "@multiformats/multiaddr" "^12.1.14"
     uint8arraylist "^2.4.8"
 
-"@libp2p/interface-peer-id@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz#6302e70b6fc17c451bc3daa11447d059357bcc32"
-  integrity sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==
-  dependencies:
-    multiformats "^11.0.0"
-
 "@libp2p/interface@^0.1.1":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-0.1.6.tgz#1328cf6086f02c499183489ccb143fe9c159e871"
@@ -5837,11 +5830,6 @@ multicodec@^1.0.0:
   dependencies:
     buffer "^5.6.0"
     varint "^5.0.0"
-
-multiformats@^11.0.0:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-11.0.2.tgz#b14735efc42cd8581e73895e66bebb9752151b60"
-  integrity sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==
 
 multiformats@^12.0.1:
   version "12.1.3"


### PR DESCRIPTION
The `node` package uses:

https://github.com/Railgun-Community/waku-relayer-client/blob/af4dd034a9915fbc20f338bea22275a3512c4cc7/packages/node/src/waku/waku-relayer-waku-core.ts#L9-L10

-----

The `web` package uses:

https://github.com/Railgun-Community/waku-relayer-client/blob/af4dd034a9915fbc20f338bea22275a3512c4cc7/packages/web/src/waku/waku-relayer-waku-core.ts#L9

-----

Other than that, there are no `@libp2p/*` deps used elsewhere.