### PR TITLE
Update shared-models and wallet to support Ink

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,6 +14,10 @@
     "test-coverage": "npm run compile-test && c8 mocha",
     "test": "npm run compile-test && NODE_ENV=test mocha"
   },
+  "resolutions": {
+    "@railgun-community/wallet": "/Users/mattgrote/code/railgun/wallet",
+    "@railgun-community/shared-models": "/Users/mattgrote/code/railgun/shared-models"
+  },
   "dependencies": {
     "@libp2p/bootstrap": "^10",
     "@waku/interfaces": "0.0.28",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,10 +14,6 @@
     "test-coverage": "npm run compile-test && c8 mocha",
     "test": "npm run compile-test && NODE_ENV=test mocha"
   },
-  "resolutions": {
-    "@railgun-community/wallet": "/Users/mattgrote/code/railgun/wallet",
-    "@railgun-community/shared-models": "/Users/mattgrote/code/railgun/shared-models"
-  },
   "dependencies": {
     "@libp2p/bootstrap": "^10",
     "@waku/interfaces": "0.0.28",
@@ -26,13 +22,13 @@
     "libp2p": "^1.8.1"
   },
   "peerDependencies": {
-    "@railgun-community/shared-models": "^7.5.0",
-    "@railgun-community/wallet": "^10.3.3",
+    "@railgun-community/shared-models": "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration",
+    "@railgun-community/wallet": "git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration",
     "ethers": "6.13.1"
   },
   "devDependencies": {
-    "@railgun-community/shared-models": "^7.5.0",
-    "@railgun-community/wallet": "^10.3.3",
+    "@railgun-community/shared-models": "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration",
+    "@railgun-community/wallet": "git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration",
     "@types/chai": "^4.3.5",
     "@types/chai-as-promised": "^7.1.5",
     "@types/leveldown": "^4.0.3",

--- a/packages/common/yarn.lock
+++ b/packages/common/yarn.lock
@@ -1591,15 +1591,13 @@
   resolved "https://registry.yarnpkg.com/@railgun-community/poseidon-hash-wasm/-/poseidon-hash-wasm-1.0.1.tgz#bfd3b3f915391a59486d8c9d632069f029e152d6"
   integrity sha512-zDAbMu095ZjMqsKIoyOnuKR4Zofnqqx4eTCtnA6qYglnexX5cadxItvJa3ozhDDTmFkDGAidDssQ7Pzl3wwLDA==
 
-"@railgun-community/shared-models@7.5.0", "@railgun-community/shared-models@^7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@railgun-community/shared-models/-/shared-models-7.5.0.tgz#d36d73740e32dbd5c21b2864e8c3db96e1241cb3"
-  integrity sha512-npSFFzSq2nSCLseEBZmLwJlZ4hMJArzEeM/DpqAAyxaTfznSHvpPIKmvEWorXVGjG+6xB7AY01TPGOq+3XHdcA==
+"@railgun-community/shared-models@git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration":
+  version "7.5.2"
+  resolved "git+https://github.com/Railgun-Community/shared-models.git#3c8547562e1d6ccc2c0fbb9dd0c93ef807de0964"
 
-"@railgun-community/wallet@^10.3.3":
+"@railgun-community/wallet@git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration":
   version "10.3.3"
-  resolved "https://registry.yarnpkg.com/@railgun-community/wallet/-/wallet-10.3.3.tgz#cef885628b76b3c547a0016f298a2e5752fb7bbe"
-  integrity sha512-dsQV7sjso7mhE15HvJliLEMLsuvUMN5wDt6hSP7nm8S+n6hsBx6tSzc5JAI7nPsi1UVDIW/f96pqMRRPRPgYxw==
+  resolved "git+https://github.com/Railgun-Community/wallet.git#6b68a73c2be39fed2984e303c92d096b6e5aa222"
   dependencies:
     "@graphql-mesh/cache-localforage" "^0.7.20"
     "@graphql-mesh/cross-helpers" "^0.3.4"
@@ -1613,7 +1611,7 @@
     "@graphql-mesh/utils" "^0.43.22"
     "@noble/ed25519" "^1.7.1"
     "@railgun-community/engine" "9.3.1"
-    "@railgun-community/shared-models" "7.5.0"
+    "@railgun-community/shared-models" "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration"
     "@whatwg-node/fetch" "^0.8.4"
     assert "2.0.0"
     axios "1.7.2"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,6 +23,10 @@
     "test": "npm run compile-test && NODE_ENV=test mocha 'dist/**/*.test.js'",
     "postinstall": "patch-package"
   },
+  "resolutions": {
+    "@railgun-community/wallet": "/Users/mattgrote/code/railgun/wallet",
+    "@railgun-community/shared-models": "/Users/mattgrote/code/railgun/shared-models"
+  },
   "dependencies": {
     "@libp2p/tcp": "9.1.5",
     "@waku/relay": "0.0.16",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,10 +23,6 @@
     "test": "npm run compile-test && NODE_ENV=test mocha 'dist/**/*.test.js'",
     "postinstall": "patch-package"
   },
-  "resolutions": {
-    "@railgun-community/wallet": "/Users/mattgrote/code/railgun/wallet",
-    "@railgun-community/shared-models": "/Users/mattgrote/code/railgun/shared-models"
-  },
   "dependencies": {
     "@libp2p/tcp": "9.1.5",
     "@waku/relay": "0.0.16",
@@ -36,12 +32,12 @@
     "@multiformats/multiaddr": "12.3.1"
   },
   "peerDependencies": {
-    "@railgun-community/shared-models": "^7.5.0",
-    "@railgun-community/wallet": "^10.3.3"
+    "@railgun-community/shared-models": "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration",
+    "@railgun-community/wallet": "git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration"
   },
   "devDependencies": {
-    "@railgun-community/shared-models": "^7.5.0",
-    "@railgun-community/wallet": "^10.3.3",
+    "@railgun-community/shared-models": "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration",
+    "@railgun-community/wallet": "git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration",
     "@types/chai": "^4.3.5",
     "@types/chai-as-promised": "^7.1.5",
     "@types/leveldown": "^4.0.3",

--- a/packages/node/yarn.lock
+++ b/packages/node/yarn.lock
@@ -1604,15 +1604,13 @@
   resolved "https://registry.yarnpkg.com/@railgun-community/poseidon-hash-wasm/-/poseidon-hash-wasm-1.0.1.tgz#bfd3b3f915391a59486d8c9d632069f029e152d6"
   integrity sha512-zDAbMu095ZjMqsKIoyOnuKR4Zofnqqx4eTCtnA6qYglnexX5cadxItvJa3ozhDDTmFkDGAidDssQ7Pzl3wwLDA==
 
-"@railgun-community/shared-models@7.5.0", "@railgun-community/shared-models@^7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@railgun-community/shared-models/-/shared-models-7.5.0.tgz#d36d73740e32dbd5c21b2864e8c3db96e1241cb3"
-  integrity sha512-npSFFzSq2nSCLseEBZmLwJlZ4hMJArzEeM/DpqAAyxaTfznSHvpPIKmvEWorXVGjG+6xB7AY01TPGOq+3XHdcA==
+"@railgun-community/shared-models@git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration":
+  version "7.5.2"
+  resolved "git+https://github.com/Railgun-Community/shared-models.git#3c8547562e1d6ccc2c0fbb9dd0c93ef807de0964"
 
-"@railgun-community/wallet@^10.3.3":
+"@railgun-community/wallet@git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration":
   version "10.3.3"
-  resolved "https://registry.yarnpkg.com/@railgun-community/wallet/-/wallet-10.3.3.tgz#cef885628b76b3c547a0016f298a2e5752fb7bbe"
-  integrity sha512-dsQV7sjso7mhE15HvJliLEMLsuvUMN5wDt6hSP7nm8S+n6hsBx6tSzc5JAI7nPsi1UVDIW/f96pqMRRPRPgYxw==
+  resolved "git+https://github.com/Railgun-Community/wallet.git#6b68a73c2be39fed2984e303c92d096b6e5aa222"
   dependencies:
     "@graphql-mesh/cache-localforage" "^0.7.20"
     "@graphql-mesh/cross-helpers" "^0.3.4"
@@ -1626,7 +1624,7 @@
     "@graphql-mesh/utils" "^0.43.22"
     "@noble/ed25519" "^1.7.1"
     "@railgun-community/engine" "9.3.1"
-    "@railgun-community/shared-models" "7.5.0"
+    "@railgun-community/shared-models" "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration"
     "@whatwg-node/fetch" "^0.8.4"
     assert "2.0.0"
     axios "1.7.2"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,10 +22,6 @@
     "test": "npm run compile-test && NODE_ENV=test mocha 'dist/**/*.test.js'",
     "postinstall": "patch-package"
   },
-  "resolutions": {
-    "@railgun-community/wallet": "/Users/mattgrote/code/railgun/wallet",
-    "@railgun-community/shared-models": "/Users/mattgrote/code/railgun/shared-models"
-  },
   "dependencies": {
     "@waku/core": "0.0.33",
     "@waku/relay": "0.0.16",
@@ -34,12 +30,12 @@
     "@multiformats/multiaddr": "12.3.1"
   },
   "peerDependencies": {
-    "@railgun-community/shared-models": "^7.5.0",
-    "@railgun-community/wallet": "^10.3.3"
+    "@railgun-community/shared-models": "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration",
+    "@railgun-community/wallet": "git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration"
   },
   "devDependencies": {
-    "@railgun-community/shared-models": "^7.5.0",
-    "@railgun-community/wallet": "^10.3.3",
+    "@railgun-community/shared-models": "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration",
+    "@railgun-community/wallet": "git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration",
     "@types/chai": "^4.3.5",
     "@types/chai-as-promised": "^7.1.5",
     "@types/leveldown": "^4.0.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,6 +22,10 @@
     "test": "npm run compile-test && NODE_ENV=test mocha 'dist/**/*.test.js'",
     "postinstall": "patch-package"
   },
+  "resolutions": {
+    "@railgun-community/wallet": "/Users/mattgrote/code/railgun/wallet",
+    "@railgun-community/shared-models": "/Users/mattgrote/code/railgun/shared-models"
+  },
   "dependencies": {
     "@waku/core": "0.0.33",
     "@waku/relay": "0.0.16",

--- a/packages/web/yarn.lock
+++ b/packages/web/yarn.lock
@@ -1543,15 +1543,13 @@
   resolved "https://registry.yarnpkg.com/@railgun-community/poseidon-hash-wasm/-/poseidon-hash-wasm-1.0.1.tgz#bfd3b3f915391a59486d8c9d632069f029e152d6"
   integrity sha512-zDAbMu095ZjMqsKIoyOnuKR4Zofnqqx4eTCtnA6qYglnexX5cadxItvJa3ozhDDTmFkDGAidDssQ7Pzl3wwLDA==
 
-"@railgun-community/shared-models@7.5.0", "@railgun-community/shared-models@^7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@railgun-community/shared-models/-/shared-models-7.5.0.tgz#d36d73740e32dbd5c21b2864e8c3db96e1241cb3"
-  integrity sha512-npSFFzSq2nSCLseEBZmLwJlZ4hMJArzEeM/DpqAAyxaTfznSHvpPIKmvEWorXVGjG+6xB7AY01TPGOq+3XHdcA==
+"@railgun-community/shared-models@git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration":
+  version "7.5.2"
+  resolved "git+https://github.com/Railgun-Community/shared-models.git#3c8547562e1d6ccc2c0fbb9dd0c93ef807de0964"
 
-"@railgun-community/wallet@^10.3.3":
+"@railgun-community/wallet@git+https://github.com/Railgun-Community/wallet.git#mattgle/ink-integration":
   version "10.3.3"
-  resolved "https://registry.yarnpkg.com/@railgun-community/wallet/-/wallet-10.3.3.tgz#cef885628b76b3c547a0016f298a2e5752fb7bbe"
-  integrity sha512-dsQV7sjso7mhE15HvJliLEMLsuvUMN5wDt6hSP7nm8S+n6hsBx6tSzc5JAI7nPsi1UVDIW/f96pqMRRPRPgYxw==
+  resolved "git+https://github.com/Railgun-Community/wallet.git#6b68a73c2be39fed2984e303c92d096b6e5aa222"
   dependencies:
     "@graphql-mesh/cache-localforage" "^0.7.20"
     "@graphql-mesh/cross-helpers" "^0.3.4"
@@ -1565,7 +1563,7 @@
     "@graphql-mesh/utils" "^0.43.22"
     "@noble/ed25519" "^1.7.1"
     "@railgun-community/engine" "9.3.1"
-    "@railgun-community/shared-models" "7.5.0"
+    "@railgun-community/shared-models" "git+https://github.com/Railgun-Community/shared-models.git#mattgle/ink-integration"
     "@whatwg-node/fetch" "^0.8.4"
     assert "2.0.0"
     axios "1.7.2"


### PR DESCRIPTION
### Summary
- Update `shared-models` and `wallet` packages to get Ink, new networking added.