### PR TITLE
Zy0n/fee signers

### DIFF
--- a/packages/common/src/__tests__/waku-broadcaster-client.test.ts
+++ b/packages/common/src/__tests__/waku-broadcaster-client.test.ts
@@ -20,7 +20,7 @@ const { expect } = chai;
 const chain = MOCK_CHAIN_ETHEREUM;
 
 const broadcasterOptions: BroadcasterOptions = {
-  trustedFeeSigner: '0zk1qyv0zc0j9sm6mr8fe3gx7ymwc6d2xymfftqvgvjdy3r8dmyfs947lrv7j6fe3z53llx97s6mxjstvn9wj3xhyv4cfecw08gqzywgnl0fmzx3mguhr2hyych4srf',
+  trustedFeeSigner: '',
 };
 
 const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';

--- a/packages/common/src/fees/__tests__/handle-authorized-fees-message.test.ts
+++ b/packages/common/src/fees/__tests__/handle-authorized-fees-message.test.ts
@@ -53,7 +53,7 @@ describe('handle-authorized-fees', function () {
   });
 
   it('Should handle valid authorized fees message', async () => {
-    handleAuthorizedFees(validFeeMessageData);
+    handleAuthorizedFees(validFeeMessageData, validFeeMessageData.railgunAddress);
 
     const expectedFees = {
       '0x1234': {
@@ -67,6 +67,11 @@ describe('handle-authorized-fees', function () {
     };
 
     expect(broadcasterFeeCacheStub.calledOnce).to.be.true;
-    expect(broadcasterFeeCacheStub.firstCall.args[0]).to.deep.equal(expectedFees);
+    expect(broadcasterFeeCacheStub.firstCall.args[0]).to.equal(
+      validFeeMessageData.railgunAddress,
+    );
+    expect(broadcasterFeeCacheStub.firstCall.args[1]).to.deep.equal(
+      expectedFees,
+    );
   });
 });

--- a/packages/common/src/fees/handle-authorized-fees-message.ts
+++ b/packages/common/src/fees/handle-authorized-fees-message.ts
@@ -8,6 +8,7 @@ import { cachedFeeExpired } from '../utils/broadcaster-util.js';
 
 export const handleAuthorizedFees = (
   feeMessageData: BroadcasterFeeMessageData,
+  signerAddress: string,
 ) => {
   try {
     if (cachedFeeExpired(feeMessageData.feeExpiration)) {
@@ -19,14 +20,6 @@ export const handleAuthorizedFees = (
     tokenAddresses.forEach(tokenAddress => {
       const feePerUnitGas = feeMessageData.fees[tokenAddress];
       if (feePerUnitGas) {
-        const existingFee = BroadcasterFeeCache.getAuthorizedFee(tokenAddress.toLowerCase());
-        if (
-          existingFee &&
-          existingFee.expiration >= feeMessageData.feeExpiration
-        ) {
-          return;
-        }
-
         const cachedFee: CachedTokenFee = {
           feePerUnitGas,
           expiration: feeMessageData.feeExpiration,
@@ -40,7 +33,7 @@ export const handleAuthorizedFees = (
     });
 
     if (Object.keys(tokenFeeMap).length > 0) {
-      BroadcasterFeeCache.addAuthorizedFees(tokenFeeMap);
+      BroadcasterFeeCache.addAuthorizedFees(signerAddress, tokenFeeMap);
       BroadcasterDebug.log('Updated Authorized Fees');
     }
   } catch (err) {

--- a/packages/common/src/fees/handle-fees-message.ts
+++ b/packages/common/src/fees/handle-fees-message.ts
@@ -119,10 +119,18 @@ const updateFeesForBroadcaster = (
   const tokenFeeMap: MapType<CachedTokenFee> = {};
   const tokenAddresses = Object.keys(feeMessageData.fees);
 
-  const isTrustedSigner =
-    BroadcasterConfig.trustedFeeSigner &&
-    feeMessageData.railgunAddress.toLowerCase() ===
-    BroadcasterConfig.trustedFeeSigner.toLowerCase();
+  let isTrustedSigner = false;
+  if (BroadcasterConfig.trustedFeeSigner) {
+    if (typeof BroadcasterConfig.trustedFeeSigner === 'string') {
+      isTrustedSigner =
+        feeMessageData.railgunAddress.toLowerCase() ===
+        BroadcasterConfig.trustedFeeSigner.toLowerCase();
+    } else {
+      isTrustedSigner = BroadcasterConfig.trustedFeeSigner.map(s =>
+        s.toLowerCase(),
+      ).includes(feeMessageData.railgunAddress.toLowerCase());
+    }
+  }
 
   if (isTrustedSigner) {
     handleAuthorizedFees(feeMessageData);

--- a/packages/common/src/fees/handle-fees-message.ts
+++ b/packages/common/src/fees/handle-fees-message.ts
@@ -133,7 +133,7 @@ const updateFeesForBroadcaster = (
   }
 
   if (isTrustedSigner) {
-    handleAuthorizedFees(feeMessageData);
+    handleAuthorizedFees(feeMessageData, feeMessageData.railgunAddress);
   }
 
   tokenAddresses.forEach(tokenAddress => {

--- a/packages/common/src/models/broadcaster-config.ts
+++ b/packages/common/src/models/broadcaster-config.ts
@@ -8,6 +8,7 @@ export class BroadcasterConfig {
   static trustedFeeSigner: string;
 
   static feeExpirationTimeout = 120_000; // 2 minutes
+  static historicalLookBackTime = 1 * 60 * 1000; // 1 minute
 
   static authorizedFeeVariancePercentageLower = 0.10; // 10% lower variance
   static authorizedFeeVariancePercentageUpper = 0.30; // 30% upper variance

--- a/packages/common/src/models/broadcaster-config.ts
+++ b/packages/common/src/models/broadcaster-config.ts
@@ -5,7 +5,7 @@ export type CustomDNSConfig = {
 export class BroadcasterConfig {
   static IS_DEV = false;
 
-  static trustedFeeSigner: string;
+  static trustedFeeSigner: string | string[];
 
   static feeExpirationTimeout = 120_000; // 2 minutes
   static historicalLookBackTime = 1 * 60 * 1000; // 1 minute

--- a/packages/common/src/models/export-models.ts
+++ b/packages/common/src/models/export-models.ts
@@ -5,7 +5,7 @@ import {
 import type { CustomDNSConfig } from './broadcaster-config.js';
 
 export type BroadcasterOptions = {
-  trustedFeeSigner: string;
+  trustedFeeSigner: string | string[];
   poiActiveListKeys?: string[];
   pubSubTopic?: string;
   additionalDirectPeers?: string[];

--- a/packages/common/src/models/export-models.ts
+++ b/packages/common/src/models/export-models.ts
@@ -11,6 +11,7 @@ export type BroadcasterOptions = {
   additionalDirectPeers?: string[];
   peerDiscoveryTimeout?: number;
   feeExpirationTimeout?: number;
+  historicalLookBackTime?: number;
   useDNSDiscovery?: boolean;
   useCustomDNS?: CustomDNSConfig,
   broadcasterVersionRange?: {

--- a/packages/common/src/search/__tests__/best-broadcaster.test.ts
+++ b/packages/common/src/search/__tests__/best-broadcaster.test.ts
@@ -22,6 +22,7 @@ describe('best-broadcaster', () => {
   beforeEach(() => {
     (BroadcasterFeeCache as any).cache = { forNetwork: {} };
     (BroadcasterFeeCache as any).authorizedFees = {};
+    (BroadcasterFeeCache as any).averageAuthorizedFees = {};
     AddressFilter.setAllowlist(undefined);
     AddressFilter.setBlocklist(undefined);
   });
@@ -32,7 +33,7 @@ describe('best-broadcaster', () => {
     // Upper 30% -> 130
 
     // Add authorized fee
-    BroadcasterFeeCache.addAuthorizedFees({
+    BroadcasterFeeCache.addAuthorizedFees(trustedSigner, {
       [tokenAddress]: {
         feePerUnitGas: authorizedFeeAmount.toString(),
         expiration: Date.now() + 100000,
@@ -183,7 +184,7 @@ describe('best-broadcaster', () => {
     const maxFee = 130n; // 30% upper
 
     // Add authorized fee
-    BroadcasterFeeCache.addAuthorizedFees({
+    BroadcasterFeeCache.addAuthorizedFees(trustedSigner, {
       [tokenAddress]: {
         feePerUnitGas: authorizedFeeAmount.toString(),
         expiration: Date.now() + 100000,
@@ -253,7 +254,7 @@ describe('best-broadcaster', () => {
     const maxFee = 130n; // 30% upper
 
     // Add authorized fee
-    BroadcasterFeeCache.addAuthorizedFees({
+    BroadcasterFeeCache.addAuthorizedFees(trustedSigner, {
       [tokenAddress]: {
         feePerUnitGas: authorizedFeeAmount.toString(),
         expiration: Date.now() + 100000,

--- a/packages/common/src/waku/waku-broadcaster-waku-core-base.ts
+++ b/packages/common/src/waku/waku-broadcaster-waku-core-base.ts
@@ -103,6 +103,9 @@ export abstract class WakuBroadcasterWakuCoreBase {
       BroadcasterConfig.feeExpirationTimeout =
         broadcasterOptions.feeExpirationTimeout;
     }
+    if (isDefined(broadcasterOptions.historicalLookBackTime)) {
+      BroadcasterConfig.historicalLookBackTime = broadcasterOptions.historicalLookBackTime
+    }
   }
 
   static async disconnect() {
@@ -171,7 +174,7 @@ export abstract class WakuBroadcasterWakuCoreBase {
     try {
       const startTime = new Date()
       // TODO: make a variable
-      startTime.setTime(Date.now() - (5 * 60 * 1000))
+      startTime.setTime(Date.now() - (BroadcasterConfig.historicalLookBackTime))
       const endTime = new Date(Date.now())
       const options: QueryRequestParams = {
         includeData: true,


### PR DESCRIPTION
This pull request introduces significant improvements to the handling and storage of authorized fees in the broadcaster service. The changes enable support for multiple trusted fee signers, refactor how authorized fees are stored and averaged, and update related tests and configuration options to accommodate these enhancements.

**Core logic and data structure improvements:**

* Refactored `BroadcasterFeeCache` to store authorized fees per signer and per token, and added logic to compute and store the average authorized fee per token, used for validation and selection. (`broadcaster-fee-cache.ts`) [[1]](diffhunk://#diff-f7e34c09579571948eff98c8e80e08a421e888824ff62a88ed8c2a6056727e8bL33-R36) [[2]](diffhunk://#diff-f7e34c09579571948eff98c8e80e08a421e888824ff62a88ed8c2a6056727e8bL165-R251)
* Updated `handleAuthorizedFees` to accept a `signerAddress` parameter and to use the new per-signer fee storage and averaging logic. (`handle-authorized-fees-message.ts`) [[1]](diffhunk://#diff-c50168d1a575e824f3a1c714a0c154027df5e50026103ed4b0f7f237ae2563ffR11) [[2]](diffhunk://#diff-c50168d1a575e824f3a1c714a0c154027df5e50026103ed4b0f7f237ae2563ffL43-R36)

**Trusted signer and configuration enhancements:**

* Changed `trustedFeeSigner` in `BroadcasterConfig` and related types to support both a single string and an array of strings, allowing multiple trusted signers. Also added a `historicalLookBackTime` configuration option. (`broadcaster-config.ts`, `export-models.ts`) [[1]](diffhunk://#diff-91d36bbf5de5a5f171abe0a04e4b1c2c94b43a325911f1337bd8467604016424L8-R11) [[2]](diffhunk://#diff-77a8aed140ba427b67b2b9000adb138d6cb1e29dc60ddd6d45c51160f6cbf347L8-R14)
* Updated logic in `handle-fees-message.ts` to check for multiple trusted signers and pass the correct address to `handleAuthorizedFees`.
* Updated `WakuBroadcasterWakuCoreBase` to set the new `historicalLookBackTime` from options and use it when querying historical messages. (`waku-broadcaster-waku-core-base.ts`) [[1]](diffhunk://#diff-9c225eb0dd77da6fe4f8460a39f0ee2f5a0a6db37d8238a236d4785ff09a8fc7R106-R108) [[2]](diffhunk://#diff-9c225eb0dd77da6fe4f8460a39f0ee2f5a0a6db37d8238a236d4785ff09a8fc7L174-R177)

**Test updates:**

* Refactored and expanded tests to cover the new per-signer fee logic, average fee computation, and enhanced validation for trusted/untrusted signers. Also added resets for the new average fee cache in test setups. (`handle-fees-message-limits.test.ts`, `handle-authorized-fees-message.test.ts`, `best-broadcaster.test.ts`, `waku-broadcaster-client.test.ts`) [[1]](diffhunk://#diff-b79698184208fb6c1a2db9f0eb649fa29dd99536474757c1bc8b455bbd7c5279R108) [[2]](diffhunk://#diff-b79698184208fb6c1a2db9f0eb649fa29dd99536474757c1bc8b455bbd7c5279R121-R123) [[3]](diffhunk://#diff-b79698184208fb6c1a2db9f0eb649fa29dd99536474757c1bc8b455bbd7c5279L144-R151) [[4]](diffhunk://#diff-b79698184208fb6c1a2db9f0eb649fa29dd99536474757c1bc8b455bbd7c5279L164-R202) [[5]](diffhunk://#diff-b79698184208fb6c1a2db9f0eb649fa29dd99536474757c1bc8b455bbd7c5279L174-R217) [[6]](diffhunk://#diff-abddcc80135c755b9fbfb99900d2058ce6533f17c80e00d6295f37807c5f1ecfL56-R56) [[7]](diffhunk://#diff-abddcc80135c755b9fbfb99900d2058ce6533f17c80e00d6295f37807c5f1ecfL70-R75) [[8]](diffhunk://#diff-b541e0252668a6676905024600ecb5ed996ed52a3f3a64f022d7d1fe9203e109R25) [[9]](diffhunk://#diff-b541e0252668a6676905024600ecb5ed996ed52a3f3a64f022d7d1fe9203e109L35-R36) [[10]](diffhunk://#diff-b541e0252668a6676905024600ecb5ed996ed52a3f3a64f022d7d1fe9203e109L186-R187) [[11]](diffhunk://#diff-b541e0252668a6676905024600ecb5ed996ed52a3f3a64f022d7d1fe9203e109L256-R257) [[12]](diffhunk://#diff-c316ae77ad48cfb36fb3ab687420bfb67448855483d6d2198ea4f51714b56fb4L23-R23)

These changes make the fee authorization process more robust, flexible, and secure by supporting multiple trusted signers and improving how authorized fees are validated and averaged across the network.