### PR TITLE
feat: add support for additional direct peers in broadcaster options

### DIFF
--- a/packages/common/src/models/broadcaster-config.ts
+++ b/packages/common/src/models/broadcaster-config.ts
@@ -18,4 +18,6 @@ export class BroadcasterConfig {
 
   static useDNSDiscovery = false
   static customDNS: CustomDNSConfig | undefined = undefined
+
+  static additionalDirectPeers: string[] = []
 }

--- a/packages/common/src/waku-broadcaster-client.ts
+++ b/packages/common/src/waku-broadcaster-client.ts
@@ -53,6 +53,10 @@ export class WakuBroadcasterClient {
       BroadcasterConfig.customDNS = broadcasterOptions.useCustomDNS
     }
 
+    if (isDefined(broadcasterOptions.additionalDirectPeers)) {
+      BroadcasterConfig.additionalDirectPeers = broadcasterOptions.additionalDirectPeers
+    }
+
     if (isDefined(broadcasterDebugger)) {
       BroadcasterDebug.setDebugger(broadcasterDebugger);
     }

--- a/packages/node/src/waku/waku-broadcaster-waku-core.ts
+++ b/packages/node/src/waku/waku-broadcaster-waku-core.ts
@@ -28,8 +28,15 @@ export class WakuBroadcasterWakuCore extends WakuBroadcasterWakuCoreBase {
           wakuDnsDiscovery(enrTreePeers),
         ]
       }
+      // handle static peers being set.
+      let directPeers: string[] = []
+      if (BroadcasterConfig.additionalDirectPeers.length) {
+        directPeers = BroadcasterConfig.additionalDirectPeers
+      }
+
       this.waku = await createLightNode({
-        defaultBootstrap: true,
+        defaultBootstrap: directPeers.length === 0,
+        bootstrapPeers: directPeers, // gets ignored if defaultBootstrap = true
         libp2p: libp2pOptions
       });
 

--- a/packages/web/src/waku/waku-broadcaster-waku-core.ts
+++ b/packages/web/src/waku/waku-broadcaster-waku-core.ts
@@ -27,9 +27,15 @@ export class WakuBroadcasterWakuCore extends WakuBroadcasterWakuCoreBase {
           wakuDnsDiscovery(enrTreePeers),
         ]
       }
+      // handle static peers being set.
+      let directPeers: string[] = []
+      if (BroadcasterConfig.additionalDirectPeers.length) {
+        directPeers = BroadcasterConfig.additionalDirectPeers
+      }
 
       this.waku = await createLightNode({
-        defaultBootstrap: true,
+        defaultBootstrap: directPeers.length === 0,
+        bootstrapPeers: directPeers, // gets ignored if defaultBootstrap = true
         libp2p: libp2pOptions
       });
 


### PR DESCRIPTION
This pull request adds support for specifying additional static peers for Waku broadcaster clients, allowing more flexible peer discovery and connectivity. The main changes introduce a new configuration option and update the initialization logic to use these peers if provided.

**Configuration enhancements:**

* Added a new static property `additionalDirectPeers` to the `BroadcasterConfig` class to store a list of peer addresses.
* Updated `WakuBroadcasterClient` to set `BroadcasterConfig.additionalDirectPeers` from the `broadcasterOptions` if specified.

**Peer connection logic updates:**

* Modified both `WakuBroadcasterWakuCore` classes (in `packages/node` and `packages/web`) to use the `additionalDirectPeers` list for peer bootstrapping: if the list is non-empty, it disables default bootstrapping and uses these peers instead. [[1]](diffhunk://#diff-2836e9cdf99254d3783628a33e706be218a390b561b801839afb2f12be70c769R31-R39) [[2]](diffhunk://#diff-59a7ab9f47d9d058076d946cc4ff4ec524fa95a0c07e28db0a9d7dcbaf89df57R30-R38)