### PR TITLE
Update release steps to provide NPM token via OIDC

### DIFF
--- a/.github/workflows/publish-npmjs.yml
+++ b/.github/workflows/publish-npmjs.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - release
       - dev
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,13 +29,9 @@ jobs:
       - name: Publish "node" package
         run: yarn publish --access public
         working-directory: ./packages/node
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build "web" package
         run: yarn build
         working-directory: ./packages/web
       - name: Publish "web" package
         run: yarn publish --access public
         working-directory: ./packages/web
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Changes:
- Updates publish-npmjs.yml to use OIDC publishing