### PR TITLE
chore: update GitHub Actions to use Node.js 24 and improve package pu…

### DIFF
--- a/.github/workflows/publish-npmjs.yml
+++ b/.github/workflows/publish-npmjs.yml
@@ -11,13 +11,14 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
+    environment: npm-release
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: Install yarn
         uses: borales/actions-yarn@v4
@@ -27,11 +28,11 @@ jobs:
         run: yarn build
         working-directory: ./packages/node
       - name: Publish "node" package
-        run: yarn publish --access public
+        run: yarn publish
         working-directory: ./packages/node
       - name: Build "web" package
         run: yarn build
         working-directory: ./packages/web
       - name: Publish "web" package
-        run: yarn publish --access public
+        run: yarn publish
         working-directory: ./packages/web

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,6 +23,14 @@
     "test": "npm run compile-test && NODE_ENV=test mocha 'dist/**/*.test.js'",
     "postinstall": "patch-package"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Railgun-Community/waku-broadcaster-client.git"
+  },
+  "homepage": "https://github.com/Railgun-Community/waku-broadcaster-client#readme",
+  "bugs": {
+    "url": "https://github.com/Railgun-Community/waku-broadcaster-client/issues"
+  },
   "dependencies": {
     "@libp2p/tcp": "^10.0.0",
     "@waku/discovery": "^0.0.13",


### PR DESCRIPTION
This pull request updates the workflow for publishing npm packages and improves metadata for the `node` package. The most important changes are grouped below by workflow improvements and package metadata enhancements.

Workflow improvements:

* Updated the GitHub Actions workflow in `.github/workflows/publish-npmjs.yml` to use newer versions of `actions/checkout` and `actions/setup-node` (`v6`), and bumped the Node.js version from `22` to `24` for builds. Also, added the `environment: npm-release` setting to the build job.
* Removed the `--access public` flag from the `yarn publish` commands for both the `node` and `web` packages, simplifying the publish step.

Package metadata enhancements:

* Added `repository`, `homepage`, and `bugs` fields to `packages/node/package.json` to provide clearer project information and support links for users.