### PR TITLE
Allow Waku client startup without Store peers

### DIFF
--- a/packages/common/src/waku/waku-broadcaster-peer-discovery-core-base.ts
+++ b/packages/common/src/waku/waku-broadcaster-peer-discovery-core-base.ts
@@ -294,7 +294,7 @@ export abstract class WakuBroadcasterPeerDiscoveryCoreBase extends WakuBroadcast
 
       BroadcasterDebug.log('Waiting for remote peer.');
       await waku.waitForPeers(
-        [Protocols.Filter, Protocols.LightPush, Protocols.Store],
+        [Protocols.Filter, Protocols.LightPush],
         this.peerDiscoveryTimeout,
       );
       BroadcasterDebug.log(this.getConnectedLogMessage());


### PR DESCRIPTION
## Why
The client currently waits for Filter, LightPush, and Store peers before considering Waku startup successful. If no Store peer is available, startup fails even though live broadcaster discovery can still work with Filter and LightPush.

Store is only needed for historical message retrieval. That path already handles query failures, so requiring a Store peer during startup makes the client unnecessarily fragile when Store infrastructure is temporarily unavailable.

## Changes
- Stop requiring `Protocols.Store` in the startup `waitForPeers` call.
- Continue requiring `Protocols.Filter` and `Protocols.LightPush` for live broadcaster message flow.