### PR TITLE
ci: remove borales/actions-yarn from workflows

### DIFF
--- a/.github/workflows/publish-npmjs.yml
+++ b/.github/workflows/publish-npmjs.yml
@@ -20,10 +20,9 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      - name: Install yarn
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Build "node" package
         run: yarn build
         working-directory: ./packages/node

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,10 +16,8 @@ jobs:
         with:
           node-version: "22"
           cache: "yarn"
-      - name: Install yarn
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Unit test
         shell: bash
         run: cd packages/web && yarn test
@@ -33,10 +31,8 @@ jobs:
         with:
           node-version: "22"
           cache: "yarn"
-      - name: Install yarn
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Unit test
         shell: bash
         run: cd packages/node && yarn test


### PR DESCRIPTION
## What

Removes `borales/actions-yarn@v4` from `publish-npmjs.yml` and `unit-tests.yml`. Replaces it with a direct `yarn install --frozen-lockfile` step. Yarn 1 is preinstalled on GitHub-hosted Ubuntu runners, so no extra setup is needed. Also adds setup-node's `cache: yarn` to `publish-npmjs.yml` for consistency with the unit-tests workflow.

## Why

`borales/actions-yarn` is a third-party action that ran inside both workflows with full access to job secrets — most notably the npm OIDC publish token in `publish-npmjs.yml`. The action does nothing that a one-line `yarn install` doesn't already do natively. Removing the wrapper shrinks the CI supply-chain surface with no behavioural change.